### PR TITLE
Skip posting into a channel if a repo should be ignored

### DIFF
--- a/webhook/packages/ghapp/redirect/redirect.py
+++ b/webhook/packages/ghapp/redirect/redirect.py
@@ -45,6 +45,10 @@ _channel_for_repository = {
     "Super-Duper-Metroid": "super-metroid-dev",
 }
 
+_ignored_repositories = {
+    "open-prime-hunters-rando"
+}
+
 ignored_users = {
     "codecov[bot]",
     "dependabot[bot]",
@@ -104,6 +108,8 @@ def process(args: dict[str, str]) -> dict:
         channel_name = channels[0]
     elif repository in _channel_for_repository:
         channel_name = _channel_for_repository[repository]
+    elif repository in _ignored_repositories:
+        pass
     else:
         channel_name = "randovania-dev"
     

--- a/webhook/packages/ghapp/redirect/redirect.py
+++ b/webhook/packages/ghapp/redirect/redirect.py
@@ -109,7 +109,7 @@ def process(args: dict[str, str]) -> dict:
     elif repository in _channel_for_repository:
         channel_name = _channel_for_repository[repository]
     elif repository in _ignored_repositories:
-        pass
+        return {"body": "ignored repository"}
     else:
         channel_name = "randovania-dev"
     


### PR DESCRIPTION
I'm not sure how much other use this would get, but this prevents specified repositories from getting posted in the server. This is handy for in development patchers or similar repos that are under the Randovania organization, but do not have a dedicated channel at the time.